### PR TITLE
fix(f39): Build from main instead of nokmods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: [-nokmods]
+        image_flavor: [-nokmods, -main]
         base_name: [asus]
         base_image_name:
           - silverblue
@@ -41,6 +41,12 @@ jobs:
             is_latest_version: true
             is_stable_version: true
         exclude:
+          - image_flavor: -nokmods
+            major_version: 39
+          - image_flavor: -main
+            major_version: 38
+          - image_flavor: -main
+            major_version: 37
           - base_image_name: vauxite
             major_version: 39
           - base_image_name: onyx
@@ -56,7 +62,7 @@ jobs:
       - name: Matrix Variables
         run: |
           echo "BASE_IMAGE_NAME=${{ matrix.base_image_name }}" >> $GITHUB_ENV
-          if [[ "${{ matrix.image_flavor }}" =~ "nokmods" ]]; then
+          if [[ "${{ matrix.image_flavor }}" =~ "nokmods" || "${{ matrix.image_flavor }}" =~ "main" ]]; then
               echo "IMAGE_NAME=${{ format('{0}-{1}', matrix.base_image_name, matrix.base_name) }}" >> $GITHUB_ENV
           else
               echo "IMAGE_NAME=${{ format('{0}-{1}{2}', matrix.base_image_name, matrix.base_name, matrix.image_flavor) }}" >> $GITHUB_ENV

--- a/Containerfile
+++ b/Containerfile
@@ -38,7 +38,6 @@ COPY --from=ghcr.io/ublue-os/akmods:asus-${FEDORA_MAJOR_VERSION} /rpms /tmp/akmo
 
 # Only run if FEDORA_MAJOR_VERSION is not 39
 RUN if [ ${FEDORA_MAJOR_VERSION} -lt 39 ]; then \
-    rpm-ostree install /tmp/akmods-rpms/ublue-os/ublue-os-akmods-addons*.rpm && \
     for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do \
         echo "akmods: enable default entry: ${REPO}" && \
         sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO} \

--- a/Containerfile
+++ b/Containerfile
@@ -26,9 +26,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/lukenukem/asus-linux/repo/fedor
         kernel-core \
         kernel-modules \
         kernel-modules-core \
-        kernel-modules-extra \
-        kernel-devel \
-        kernel-devel-matched && \
+        kernel-modules-extra && \
     git clone https://gitlab.com/asus-linux/firmware.git --depth 1 /tmp/asus-firmware && \
     cp -rf /tmp/asus-firmware/* /usr/lib/firmware/ && \
     rm -rf /tmp/asus-firmware


### PR DESCRIPTION
nokmods is deprecated from Fedora 39 onward