### PR TITLE
fix: remove extra - in version variable which leads to invalid name with --

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Get current Fedora version
         id: labels
         run: |
-            ver=$(skopeo inspect docker://ghcr.io/ublue-os/${{ matrix.base_image_name }}-${{ matrix.image_flavor }}:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
+            ver=$(skopeo inspect docker://ghcr.io/ublue-os/${{ matrix.base_image_name }}${{ matrix.image_flavor }}:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
             echo "VERSION=$ver" >> $GITHUB_OUTPUT
 
       # Build metadata


### PR DESCRIPTION
Related to https://github.com/ublue-os/surface/pull/34, this resolves the issue where the image version tag is empty.