### PR TITLE
chore(ci): lazurite 39 builds supercede lxqt 38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           - sericea
           - base
           - lxqt
+          - lazurite
           - mate
           - onyx
         major_version: [38, 39]
@@ -56,8 +57,14 @@ jobs:
             major_version: 38
           - image_flavor: -main
             major_version: 37
+          # There is no Fedora 38 version of onyx or lazurite
+          - base_image_name: lazurite
+            major_version: 38
           - base_image_name: onyx
             major_version: 38
+          # lazurite supercedes lxqt in Fedora 39
+          - base_image_name: lxqt
+            major_version: 39
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
related to upstream main/nvidia changes